### PR TITLE
Correct flake import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ for building Android apps or libraries.
   };
 
   outputs = { self, android }: {
-    packages.x86_64-linux.android-sdk = android.sdk (sdkPkgs: with sdkPkgs; [
+    packages.x86_64-linux.android-sdk = android.sdk.x86_64-linux (sdkPkgs: with sdkPkgs; [
       cmdline-tools-latest
       build-tools-30-0-2
       platform-tools


### PR DESCRIPTION
In the flake, the sdk output depends on the platform. The example should show android.sdk.x86_64-linux in order to be functional.