### PR TITLE
Add missing dir JAVA_OPT parameters

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "devshell": {
       "locked": {
-        "lastModified": 1631528035,
-        "narHash": "sha256-ZV4+WsrF1uaAOM2ynGzWD5dCmrWpKc+Rj1hZkodEPQY=",
+        "lastModified": 1636119665,
+        "narHash": "sha256-e11Z9PyH9hdgTm4Vyl8S5iTwrv0um6+srzb1Ba+YUHA=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd0d585d2ed42b9d226673dd56d4fe2dfd0bf0dc",
+        "rev": "ab14b1a3cb253f58e02f5f849d621292fbf81fad",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631962327,
-        "narHash": "sha256-h2fgtNHozEcB42BQ1QVWAJUpQ1FA3gpgq/RrOKAxbfE=",
+        "lastModified": 1636267212,
+        "narHash": "sha256-KDS173KqmqrYUPY9N4vf750GxIo+S6E0djyq2BsQm8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc9b956714ed6eac5f8888322aac5bc41389defa",
+        "rev": "c935f5e0add2cf0ae650d072c8357533e21b0c35",
         "type": "github"
       },
       "original": {

--- a/pkgs/android/cmdline-tools.nix
+++ b/pkgs/android/cmdline-tools.nix
@@ -9,7 +9,8 @@ mkGeneric
       makeWrapper $script $out/bin/$(basename $script) \
         --set-default JAVA_HOME "${jdk.home}" \
         --set-default ANDROID_SDK_ROOT $ANDROID_SDK_ROOT \
-        --prefix JAVA_OPTS ' ' "-Dcom.android.sdklib.toolsdir=$pkgBase"
+        --prefix JAVA_OPTS ' ' "-Dcom.android.sdklib.toolsdir=$pkgBase" \
+        --prefix JAVA_OPTS ' ' "-Dcom.android.sdkmanager.toolsdir=$pkgBase"
       done
   '';
 }

--- a/pkgs/android/cmdline-tools.nix
+++ b/pkgs/android/cmdline-tools.nix
@@ -10,7 +10,8 @@ mkGeneric
         --set-default JAVA_HOME "${jdk.home}" \
         --set-default ANDROID_SDK_ROOT $ANDROID_SDK_ROOT \
         --prefix JAVA_OPTS ' ' "-Dcom.android.sdklib.toolsdir=$pkgBase" \
-        --prefix JAVA_OPTS ' ' "-Dcom.android.sdkmanager.toolsdir=$pkgBase"
+        --prefix JAVA_OPTS ' ' "-Dcom.android.sdkmanager.toolsdir=$pkgBase" \
+        --prefix JAVA_OPTS ' ' "-Dcom.android.tools.lint.bindir=$pkgBase"
       done
   '';
 }


### PR DESCRIPTION
Fixes #12 

I checked through your CI config and it looks like all the channel branches (stable, beta, etc) automatically get synced from `main` so I've only opened this PR against the main branch. Let me know if I need to do more PRs to other branches.

While I was at it, I had a hunch there might be another missing one. Sure enough, apparently the lint cmdline tool has its own `-Dcom.android.tools.lint.bindir` configuration flag; I've added that into this PR with the same rationale. It might be worth looking into seeing if `APP_DIR` itself should be mucked around with in the scripts, but for now this will work.