### PR TITLE
Fix failed to build env with Android SDK Tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
             ndk-bundle
             platform-tools
             platforms-android-32
+            tools
           ]);
         };
 

--- a/pkgs/android/tools.nix
+++ b/pkgs/android/tools.nix
@@ -49,8 +49,8 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
       makeWrapper $exe $out/bin/$(basename $exe) --set JAVA_HOME "${jdk8.home}"
     done
     makeWrapper $pkgBase/bin/sdkmanager $out/bin/sdkmanager \
+      --add-flags '--sdk_root="$ANDROID_HOME"' \
       --set JAVA_HOME "${jdk8.home}" \
-      --set-default ANDROID_HOME $ANDROID_HOME \
-      --add-flags '--sdk_root="$ANDROID_HOME"'
+      --set-default ANDROID_HOME $ANDROID_HOME 
   '';
 })


### PR DESCRIPTION
Ref: https://github.com/NixOS/nixpkgs/issues/85510

```
❯ nix log /nix/store/av7a1xl6xklri5zgvrln0xq7lzf51448-android-sdk-env.drv

Builder called die: makeWrapper doesn't understand the arg --sdk_root="$ANDROID_HOME"
Backtrace:
105 makeWrapper /nix/store/2qq7k7iql04fv2kwjr1hc4p1rd7i2n77-hook/nix-support/setup-hook
69 source /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90
1317 genericBuild /nix/store/agwlk2bcfvz2ggrsbvwd7696qj55frbi-stdenv-linux/setup
2 main /nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh
```