### PR TITLE
update nix flake init template comments

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -38,8 +38,8 @@
 
             # Other useful packages for a development environment.
             # sources-android-30
-            # system-images-android-30-google-apis
-            # system-images-android-30-google-apis-playstore
+            # system-images-android-30-google-apis-x86
+            # system-images-android-30-google-apis-playstore-x86
           ]);
 
           android-studio = pkgs.androidStudioPackages.stable;


### PR DESCRIPTION
`system-images-android-30-google-apis` and `system-images-android-30-google-apis-playstore` do not exist on their own