### PR TITLE
emulator: Use vendored libvulkan and swiftshader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1650389807,
-        "narHash": "sha256-GFRBdHMJ/T/ifaE2GS58RWpxyufH0LqI3oGS6oWAnHk=",
+        "lastModified": 1650900878,
+        "narHash": "sha256-qhNncMBSa9STnhiLfELEQpYC1L4GrYHNIzyCZ/pilsI=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "5a53bbf3eb4c908d83884d725a86b3a3bde35979",
+        "rev": "d97df53b5ddaa1cfbea7cddbd207eb2634304733",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1651007983,
+        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
         "type": "github"
       },
       "original": {

--- a/pkgs/android/emulator.nix
+++ b/pkgs/android/emulator.nix
@@ -30,7 +30,6 @@
 , nss
 , nspr
 , sqlite
-, swiftshader
 , systemd
 , vulkan-loader
 , xkeyboard_config
@@ -69,8 +68,6 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
       nss
       nspr
       sqlite
-      swiftshader
-      vulkan-loader
       zlib
     ];
 
@@ -78,12 +75,10 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     dontWrapQtApps = true;
 
     postUnpack = ''
+      # Vendored gles_mesa is out of date and causes the following:
+      #     LLVM ERROR: Cannot select: intrinsic %llvm.x86.sse41.pblendvb
+      #     Segmentation fault (core dumped)
       rm -r $out/lib64/gles_mesa
-      rm -r $out/lib64/vulkan/*
-      ln -s $(realpath ${vulkan-loader}/lib/libvulkan.so.1) $out/lib64/vulkan/libvulkan.so.1
-      ln -s ${swiftshader}/lib/libEGL.so $out/lib64/vulkan/
-      ln -s ${swiftshader}/lib/libvk_swiftshader.so $out/lib64/vulkan/
-      ln -s ${swiftshader}/share/vulkan/icd.d/vk_swiftshader_icd.json $out/lib64/vulkan/
 
       # Force XCB platform plugin as Wayland isn't supported.
       # Inject libudev0-shim to fix udev_loader error.


### PR DESCRIPTION
The `swiftshader` build is broken in nixpkgs, probably due to GCC 11. Switch back to the vendored swiftshader/libvulkan libs.

`libGL` is still required as the vendored version includes an ancient bug that fails to select SSE4.1 intrinsics.