### PR TITLE
Remove duplicate flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,11 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    devshell.url = "github:numtide/devshell";
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "nixpkgs";
+    };
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
This way, one does not end up downloading multiple copies of e.g. `nixpkgs`.