### PR TITLE
home-manager: Fix ANDROID_HOME and ANDROID_SDK_ROOT variables

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -51,8 +51,8 @@ in
       file.${cfg.path}.source = "${cfg.finalPackage}/share/android-sdk";
       packages = [ cfg.finalPackage ];
       sessionVariables = {
-        ANDROID_HOME = config.home.file.${cfg.path}.target;
-        ANDROID_SDK_ROOT = config.home.file.${cfg.path}.target;
+        ANDROID_HOME = cfg.path;
+        ANDROID_SDK_ROOT = cfg.path;
       };
     };
   };


### PR DESCRIPTION
Fixes #64. I've used this locally now for a bit and it works for me.