### PR TITLE
fix: compatibility with Flutter

### DIFF
--- a/pkgs/android/cmdline-tools.nix
+++ b/pkgs/android/cmdline-tools.nix
@@ -5,13 +5,16 @@ mkGeneric
   pname = "cmdline-tools";
 
   passthru.installSdk = ''
+    chmod +w $pkgBase/bin
     for script in $pkgBase/bin/*; do
-      makeWrapper $script $out/bin/$(basename $script) \
+      wrapProgram $script \
         --set-default JAVA_HOME "${jdk.home}" \
         --set-default ANDROID_SDK_ROOT $ANDROID_SDK_ROOT \
         --prefix JAVA_OPTS ' ' "-Dcom.android.sdklib.toolsdir=$pkgBase" \
         --prefix JAVA_OPTS ' ' "-Dcom.android.sdkmanager.toolsdir=$pkgBase" \
         --prefix JAVA_OPTS ' ' "-Dcom.android.tools.lint.bindir=$pkgBase"
-      done
+      ln -rvs $script $out/bin/$(basename $script)
+    done
+    chmod -w $pkgBase/bin
   '';
 }


### PR DESCRIPTION
This PR is a duplicate of #71 created for cleaner merge from a separate branch, because I started to use main branch actively.

_Original description:_

When using this flake with Flutter package, it fails to find SDK, because Flutter CLI uses hard-coded path to `<sdkroot>/cmdline-tools/<version>/bin/sdkmanager` (see [source code](https://github.com/flutter/flutter/blob/1bad8c4f45846b9c5a3a6e4ec8ede639da330ef9/packages/flutter_tools/lib/src/android/android_sdk.dart#L269)).

sdkmanager executed from SDK package stubbornly ignores `ANDROID_SDK_ROOT` and `ANDROID_HOME`  values.

This change fixes the issues #61 and probably #18