### PR TITLE
Filter packages with broken/unsupported inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,11 +7,34 @@ with pkgs;
 let
   androidSdk = callPackage ./pkgs/android { };
 
-  isSupported = _: pkg:
-    if (!lib.isDerivation pkg) then true
-    else builtins.elem system pkg.meta.platforms;
+  getName = attrs: attrs.name or ("${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}");
 
-  filterIsSupported = lib.filterAttrs isSupported;
+  isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
+  allowInsecureDefaultPredicate = x: builtins.elem (getName x) (config.permittedInsecurePackages or [ ]);
+  allowInsecurePredicate = x: (config.allowInsecurePredicate or allowInsecureDefaultPredicate) x;
+  hasAllowedInsecure = attrs:
+    !(isMarkedInsecure attrs) ||
+    allowInsecurePredicate attrs ||
+    builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+
+  isMarkedBroken = attrs: attrs.meta.broken or false;
+  allowBroken = config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
+  hasAllowedBroken = attrs:
+    !(isMarkedBroken attrs) || allowBroken;
+
+  allowUnsupportedSystem = config.allowUnsupportedSystem
+    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+
+  isSupported = pkg:
+    lib.meta.availableOn hostPlatform pkg || allowUnsupportedSystem;
+
+  filterIsSupported = lib.filterAttrs (_: pkg:
+    (!lib.isDerivation pkg) || (
+      isSupported pkg &&
+      hasAllowedBroken pkg &&
+      hasAllowedInsecure pkg
+    )
+  );
 
   channelPkgs = rec {
     stable = filterIsSupported (androidSdk.callPackage ./channels/stable { });

--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -61,5 +61,7 @@ stdenv.mkDerivation (rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ tadfisher ];
     inherit platforms;
+    broken = builtins.any (p: p.meta.broken or false) (nativeBuildInputs ++ (args.buildInputs or [ ]));
+    knownVulnerabilities = lib.concatMap (p: p.meta.knownVulnerabilities or [ ]) (nativeBuildInputs ++ (args.buildInputs or [ ]));
   } // (args.meta or { });
 } // removeAttrs args [ "nativeBuildInputs" "passthru" "meta" "unzipCmd" ])

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -101,7 +101,7 @@ let
     dontPatchELF = true;
     dontAutoPatchelf = true;
     autoPatchelfIgnoreMissingDeps = [ "liblog.so" ];
-  } // {
+
     passthru.installSdk = ''
       ln -sf $pkgBase/ndk-build $out/bin/ndk-build
     '';


### PR DESCRIPTION
python2.7 was marked insecure via `meta.knownVulnerabilities`, which broke the oldest NDK package. Inherit `meta.broken` and `meta.knownVulnerabilities` from nativeBuildInputs + buildInputs, and filter these packages out if the requisite env-var/nixpkgs.config isn't set.