### PR TITLE
Handle python27 better

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,34 +7,11 @@ with pkgs;
 let
   androidSdk = callPackage ./pkgs/android { };
 
-  getName = attrs: attrs.name or ("${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}");
+  isSupported = _: pkg:
+    if (!lib.isDerivation pkg) then true
+    else builtins.elem system pkg.meta.platforms;
 
-  isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
-  allowInsecureDefaultPredicate = x: builtins.elem (getName x) (config.permittedInsecurePackages or [ ]);
-  allowInsecurePredicate = x: (config.allowInsecurePredicate or allowInsecureDefaultPredicate) x;
-  hasAllowedInsecure = attrs:
-    !(isMarkedInsecure attrs) ||
-    allowInsecurePredicate attrs ||
-    builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
-
-  isMarkedBroken = attrs: attrs.meta.broken or false;
-  allowBroken = config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
-  hasAllowedBroken = attrs:
-    !(isMarkedBroken attrs) || allowBroken;
-
-  allowUnsupportedSystem = config.allowUnsupportedSystem
-    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
-
-  isSupported = pkg:
-    lib.meta.availableOn hostPlatform pkg || allowUnsupportedSystem;
-
-  filterIsSupported = lib.filterAttrs (_: pkg:
-    (!lib.isDerivation pkg) || (
-      isSupported pkg &&
-      hasAllowedBroken pkg &&
-      hasAllowedInsecure pkg
-    )
-  );
+  filterIsSupported = lib.filterAttrs isSupported;
 
   channelPkgs = rec {
     stable = filterIsSupported (androidSdk.callPackage ./channels/stable { });

--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,10 @@ let
   androidSdk = callPackage ./pkgs/android { };
 
   isSupported = _: pkg:
-    if (!lib.isDerivation pkg) then true
-    else builtins.elem system pkg.meta.platforms;
+    (!lib.isDerivation pkg) ||
+    lib.meta.availableOn hostPlatform pkg ||
+    config.allowUnsupportedSystem ||
+    builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
 
   filterIsSupported = lib.filterAttrs isSupported;
 

--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -62,7 +62,5 @@ stdenv.mkDerivation (rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ tadfisher ];
     inherit platforms;
-    broken = builtins.any (p: p.meta.broken or false) (nativeBuildInputs ++ (args.buildInputs or [ ]));
-    knownVulnerabilities = lib.concatMap (p: p.meta.knownVulnerabilities or [ ]) (nativeBuildInputs ++ (args.buildInputs or [ ]));
   } // (args.meta or { });
 } // removeAttrs args [ "nativeBuildInputs" "passthru" "meta" "unzipCmd" ])

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -104,7 +104,7 @@ let
     dontPatchELF = true;
     dontAutoPatchelf = true;
     autoPatchelfIgnoreMissingDeps = [ "liblog.so" ];
-
+  } // {
     passthru.installSdk = ''
       ln -sf $pkgBase/ndk-build $out/bin/ndk-build
     '';

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -13,6 +13,11 @@
 , zlib ? null
 }:
 
+let
+  python27Versions = [ "16" "21" ];
+
+in
+
 assert stdenv.isLinux -> autoPatchelfHook != null;
 assert stdenv.isLinux -> libxcrypt-legacy != null;
 assert stdenv.isLinux -> ncurses5 != null;
@@ -25,8 +30,6 @@ let
 in
 
 assert (stdenv.isLinux && lib.versionOlder versionMajor "18") -> libedit != null;
-assert (stdenv.isLinux && versionMajor == "16") -> openssl != null;
-assert (stdenv.isLinux && versionMajor == "16") -> sqlite != null;
 
 let
   runtimePaths = lib.makeBinPath (with pkgsHostHost; [
@@ -63,7 +66,7 @@ let
       zlib
     ] ++ lib.optionals (lib.versionOlder versionMajor "18") [
       libedit
-    ] ++ lib.optionals (versionMajor == "16") [
+    ] ++ lib.optionals (builtins.elem versionMajor python27Versions) [
       python27
     ]);
 
@@ -74,7 +77,7 @@ let
       ln -sf ${libedit}/lib/libedit.so $out/toolchains/llvm/prebuilt/linux-x86_64/lib64/libedit.so.2
       ''}
 
-      ${lib.optionalString (stdenv.isLinux && versionMajor == "16") ''
+      ${lib.optionalString (stdenv.isLinux && builtins.elem versionMajor python27Versions) ''
       rm -rf $out/prebuilt/*/lib/python2.7
       ''}
 


### PR DESCRIPTION
Don't filter out "insecure" packages, we already add python27 to nixpkgs.config.permittedInsecurePackages.

Add the python27 input for NDK versions 16 and 21; fixes #62 