### PR TITLE
Updated `build-tools` scripts to use `wrapProgram`.

### DIFF
--- a/pkgs/android/build-tools.nix
+++ b/pkgs/android/build-tools.nix
@@ -1,8 +1,10 @@
 { stdenv
 , lib
+, makeWrapper
 , mkGeneric
 , autoPatchelfHook
 , coreutils
+, jdk
 , libcxx
 , ncurses5
 , zlib
@@ -11,6 +13,7 @@
 mkGeneric (lib.optionalAttrs stdenv.isLinux {
   nativeBuildInputs = [
     autoPatchelfHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -27,8 +30,9 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux {
   ];
 
   postUnpack = ''
-    for f in $(grep -l -a -r "/bin/ls" $out); do
-      substituteInPlace $f --replace "/bin/ls" "${coreutils}/bin/ls"
+    for f in apksigner d8 lld; do
+      substituteInPlace "$out/$f" --replace "/bin/ls" "ls"
+      wrapProgram "$out/$f" --set PATH ${lib.makeBinPath [coreutils jdk]}
     done
   '';
 })


### PR DESCRIPTION
Follow up to https://github.com/tadfisher/android-nixpkgs/pull/34.

Changed from iterating `grep` to a fixed list of files, as something like `expr` is too general and shows up in other places.  @eliasnaur hopefully this is what you were envisioning with `wrapProgram`?

