### PR TITLE
Unpin jdk version

### DIFF
--- a/template/devshell.nix
+++ b/template/devshell.nix
@@ -21,13 +21,13 @@ devshell.mkShell {
     }
     {
       name = "JAVA_HOME";
-      value = jdk11.home;
+      value = jdk.home;
     }
   ];
   packages = [
     android-studio
     android-sdk
     gradle
-    jdk11
+    jdk
   ];
 }


### PR DESCRIPTION
This addresses https://github.com/tadfisher/android-nixpkgs/issues/86

Unpin the jdk version, so the devshell java will use the same java as the android sdk.