### PR TITLE
Only include android-studio if not on aarch64-darwin

### DIFF
--- a/template/devshell.nix
+++ b/template/devshell.nix
@@ -2,6 +2,12 @@
 
 with pkgs;
 
+let
+  # android-studio is not available in aarch64-darwin
+  conditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [];
+in
+with pkgs;
+
 # Configure your development environment.
 #
 # Documentation: https://github.com/numtide/devshell
@@ -25,9 +31,8 @@ devshell.mkShell {
     }
   ];
   packages = [
-    android-studio
     android-sdk
     gradle
     jdk
-  ];
+  ] ++ conditionalPackages;
 }

--- a/template/devshell.nix
+++ b/template/devshell.nix
@@ -4,7 +4,7 @@ with pkgs;
 
 let
   # android-studio is not available in aarch64-darwin
-  conditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [];
+  conditionalPackages = if pkgs.system != "aarch64-darwin" then [ android-studio ] else [];
 in
 with pkgs;
 

--- a/template/devshell.nix
+++ b/template/devshell.nix
@@ -4,7 +4,7 @@ with pkgs;
 
 let
   # android-studio is not available in aarch64-darwin
-  conditionalPackages = if pkgs.system != "aarch64-darwin" then [ android-studio ] else [];
+  conditionalPackages = if pkgs.system != "aarch64-darwin" then [ android-studio ] else [ ];
 in
 with pkgs;
 


### PR DESCRIPTION
This fixes https://github.com/tadfisher/android-nixpkgs/issues/85

The template devshell.nix included android-studio unconditionally, which causes errors on aarch64-darwin. This PR makes it so that android-studio is only included on non aarch64-darwin.