### PR TITLE
allow all python packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,7 @@
               (devshell.overlay)
               (self.overlay)
             ];
-            permittedInsecurePackages = [
-              "python-2.7.18.7"
-            ];
+            allowInsecurePredicate = pkg: pkg.pname == "python";
           };
         };
 


### PR DESCRIPTION
Python 2 has version 2.7.18.8 in the latest nixpkgs, which causes an error. This change makes all python packages allowed, not just a specific version