### PR TITLE
disable hooks that are disabled in nixpkgs

### DIFF
--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -13,7 +13,10 @@ let
 
 in
 stdenv.mkDerivation (rec {
-  dontStrip = args.dontStrip or false;
+  # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
+  dontStrip = true;
+  dontPatchELF = true;
+  dontAutoPatchelf = true;
 
   inherit (package) pname version;
 

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -100,9 +100,6 @@ let
       wrapProgram $out/ndk-build --prefix PATH : "${runtimePaths}"
     '';
 
-    dontStrip = true;
-    dontPatchELF = true;
-    dontAutoPatchelf = true;
     autoPatchelfIgnoreMissingDeps = [ "liblog.so" ];
   } // {
     passthru.installSdk = ''

--- a/pkgs/android/prebuilt.nix
+++ b/pkgs/android/prebuilt.nix
@@ -19,12 +19,7 @@ let
         buildInputs = [ ncurses5 stdenv.cc.cc.lib ];
       }
       else { }
-    ) // lib.optionalAttrs stdenv.isDarwin (
-    if (hasPrefix "cmake;" id) then {
-      dontStrip = true;
-    }
-    else { }
-  );
+    );
 
 in
 mkGeneric buildArgs package


### PR DESCRIPTION
This is a more general fix for #93. It's assumed that only one of #95 and #96 will be merged

As far as I can tell `pkgs/android/generic.nix` is the same as `pkgs/development/mobile/androidenv/deploy-androidpackages.nix` in nixpkgs, shouldn't we disable all those hooks that are disabled in nixpkgs?

<https://github.com/NixOS/nixpkgs/blob/d84b5d7735fe905a4c89548fabeb71a7abb2d548/pkgs/development/mobile/androidenv/deploy-androidpackages.nix#L108-L111>