### PR TITLE
Add postUnpack hook to run autoPatchelf for platform-tools.nix file.

### DIFF
--- a/pkgs/android/platform-tools.nix
+++ b/pkgs/android/platform-tools.nix
@@ -11,7 +11,7 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     ];
 
     postUnpack = ''
-        autoPatchelf $out
+      autoPatchelf $out
     '';
 
   } // {

--- a/pkgs/android/platform-tools.nix
+++ b/pkgs/android/platform-tools.nix
@@ -9,6 +9,11 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     buildInputs = [
       stdenv.cc.cc.lib
     ];
+
+    postUnpack = ''
+        autoPatchelf $out
+    '';
+
   } // {
   passthru.installSdk = ''
     for exe in adb dmtracedump e2fsdroid etc1tool fastboot hprof-conv make_f2fs mke2fs sload_f2fs; do


### PR DESCRIPTION
In addition to [this PR](https://github.com/tadfisher/android-nixpkgs/pull/100) which  fixed the emulator command, this fixes the `adb` command  from platform tools (and maybe others). 

Prior to the change, attempting to run `adb` would give the following (on nixOS):
```text
Could not start dynamically linked executable: adb
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

After the change, the command works as normal. 

For additional context, the dependencies missing were (`libtree $(where adb)`):

```text
/nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/adb 
├── librt.so.1 not found
└── libpthread.so.0 not found
    ┊ Paths considered in this order:
    ┊ 1. rpath is skipped because runpath was set
    ┊ 2. LD_LIBRARY_PATH:
    ┊    /nix/store/is7dfka7vihiig3w789s1b0az40cgmrj-pipewire-1.0.6-jack/lib
    ┊ 3. runpath:
    ┊    /nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/
    ┊    /nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/lib64
    ┊    /nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/../lib64
    ┊    /nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/../../lib64
    ┊    /nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/../../../lib64
    ┊ 4. ld config files:
    ┊ 5. Standard paths:
    ┊    /lib
    ┊    /lib64
    ┊    /usr/lib
    ┊    /usr/lib64
Error [/nix/store/mk2kjhgga1fdsvh3ribqs2m8mjwal1y5-android-project-2-dir/bin/adb]: Not all dependencies were found
```
