### PR TITLE
Add autoPatchelf to postUnpack in various packages

### DIFF
--- a/pkgs/aapt2/default.nix
+++ b/pkgs/aapt2/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $out/bin/aapt2
   '';
 
+
+  postUnpack = ''
+    autoPatchelf $out
+  '';
+
   meta = with lib; {
     description = "Android Asset Packaging Tool";
     platforms = [ "x86_64-linux" ];

--- a/pkgs/android/build-tools.nix
+++ b/pkgs/android/build-tools.nix
@@ -30,6 +30,8 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux {
   ];
 
   postUnpack = ''
+    autoPatchelf $out
+
     for f in apksigner d8 lld; do
       substituteInPlace "$out/$f" --replace "/bin/ls" "ls"
       wrapProgram "$out/$f" --set PATH ${lib.makeBinPath [coreutils jdk]}

--- a/pkgs/android/prebuilt.nix
+++ b/pkgs/android/prebuilt.nix
@@ -17,6 +17,10 @@ let
       if (hasPrefix "cmake;" id || hasPrefix "skiaparser;" id) then {
         nativeBuildInputs = [ autoPatchelfHook ];
         buildInputs = [ ncurses5 stdenv.cc.cc.lib ];
+        
+        postUnpack = ''
+            autoPatchelf $out
+        '';
       }
       else { }
     );

--- a/pkgs/android/tools.nix
+++ b/pkgs/android/tools.nix
@@ -38,6 +38,8 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     ];
 
     postUnpack = ''
+      autoPatchelf $out
+
       for f in $(grep -l -a -r "/bin/ls" $out); do
         substituteInPlace $f --replace "/bin/ls" "${coreutils}/bin/ls"
       done


### PR DESCRIPTION
In response to #103, I've added `autoPathelf $out` to various packages. I haven't tested every executable, except for `cmake` in  `pkgs/android/prebuilt.nix`. 

In this case, when 'bringing `cmake-3-22-1` into' the flake without applying `autoPatchelf $out`:

<details>

<summary> flake.nix </summary>

```nix
{
  description = "My Android project";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs";
    devshell.url = "github:numtide/devshell";
    flake-utils.url = "github:numtide/flake-utils";
    android.url = "path:/home/harryp/Code/android-nixpkgs-fork";
  };

  outputs = { self, nixpkgs, devshell, flake-utils, android }:
    {
      overlay = final: prev: {
        inherit (self.packages.${final.system}) android-sdk android-studio;
      };
    }
    //
    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ] (system:
      let
        inherit (nixpkgs) lib;
        pkgs = import nixpkgs {
          inherit system;
          config.allowUnfree = true;
          overlays = [
            devshell.overlays.default
            self.overlay
          ];
        };
        defaultBuildToolsVersion = "34.0.0";
      in
      {
        packages = {
          android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
            build-tools-34-0-0
            cmdline-tools-latest
            emulator
            platform-tools
            platforms-android-34
            cmake-3-22-1 # <------- Here ---------
            ndk-26-1-10909125
          ]
          ++ lib.optionals (system == "aarch64-darwin") [
            system-images-android-34-google-apis-arm64-v8a
          ]
          ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
            system-images-android-34-google-apis-x86-64
          ]);
        } // lib.optionalAttrs (system == "x86_64-linux") {
          android-studio = pkgs.androidStudioPackages.stable;
        };
        devShell = import ./devshell.nix { inherit pkgs; defaultBuildToolsVersion = defaultBuildToolsVersion; };
      }
    );
}
```
(Still new to nix and android so not sure exactly what happens when I specify `cmake-3-22-1` in the sdk.system argument)

</details>

This causes the react native expo build commands to fail:

```log
> Task :expo-modules-core:configureCMakeDebug[arm64-v8a] FAILED
C/C++: Could not start dynamically linked executable: /nix/store/gx3vflzrb8qmbzfdfhlfbvzlqwsywq60-android-sdk-env/share/android-sdk/cmake/3.22.1/bin/cmake
C/C++: NixOS cannot run dynamically linked executables intended for generic
C/C++: linux environments out of the box. For more information, see:
C/C++: https://nix.dev/permalink/stub-ld
```

Full expo commands to reproduce the expo cmake error:

```bash
npx create-expo-app@latest

# Say yes to everything with default `my-app` application name.

cd my-app

npx expo install expo-dev-client

npx expo run:android

# You may also need to create an android virtual device with

avdmanager create avd -n android-avd-test -k "system-images;android-34;google_apis;x86_64"

```

<details>

<summary> devshell.nix </summary>

```nix

{ pkgs, defaultBuildToolsVersion }:
with pkgs; let
  # android-studio is not available in aarch64-darwin
  conditionalPackages =
    if pkgs.system != "aarch64-darwin"
    then [android-studio]
    else [];

  avdRoot = "$PWD/.android/avd";
in
  with pkgs;
    devshell.mkShell {
      name = "android-project";
      motd = ''
        Entered the Android app development environment.
      '';
      env = [
        {
          name = "ANDROID_HOME";
          value = "${android-sdk}/share/android-sdk";
        }
        {
          name = "ANDROID_SDK_ROOT";
          value = "${android-sdk}/share/android-sdk";
        }
        {
          name = "JAVA_HOME";
          value = openjdk17.home;
        }
        {
          name = "GRADLE_HOME";
          value = "${gradle}/bin";
        }
        {
          name = "GRADLE_OPTS";
          value = "-Dorg.gradle.java.home=${openjdk17.home} -Dorg.gradle.project.android.aapt2FromMavenOverride=${android-sdk}/share/android-sdk/build-tools/${defaultBuildToolsVersion}/aapt2";
        }
      ];
      packages =
        [
          android-sdk
          gradle
          openjdk17
          cmake
          # expo
          watchman
          nodejs_22
          ninja
        ]
        ++ conditionalPackages;

      devshell.startup.avdroot.text = ''
        echo "Creating android avd root as ${avdRoot}"
        mkdir -p "${avdRoot}"

        echo "Exporting ANDROID_AVD_HOME"
        export ANDROID_AVD_HOME="${avdRoot}"
      '';
    }
```
</details>

After running `autoPatchelf $out`  I am able to run the expo commands and create a dev environment with an emulator 
