### PR TITLE
Re-enable `autoPatchelfHook`

### DIFF
--- a/pkgs/aapt2/default.nix
+++ b/pkgs/aapt2/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoPatchelfHook patchelf unzip ];
 
+  buildInputs = [ stdenv.cc.cc.lib ];
+
   unpackCmd = "unzip $curSrc -d ${name}";
 
   installPhase = ''

--- a/pkgs/android/emulator.nix
+++ b/pkgs/android/emulator.nix
@@ -93,8 +93,6 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
       patchelf --replace-needed libtiff.so.5 libtiff.so \
         $out/lib64/qt/plugins/imageformats/libqtiffAndroidEmu.so
 
-      autoPatchelf $out
-
       # Force XCB platform plugin as Wayland isn't supported.
       # Inject libudev0-shim to fix udev_loader error.
       wrapProgram $out/emulator \

--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation ({
   # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
   dontStrip = true;
   dontPatchELF = true;
-  dontAutoPatchelf = true;
 
   inherit (package) pname version;
 

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -4,6 +4,7 @@
 , makeWrapper
 , pkgsHostHost
 , autoPatchelfHook ? null
+, bzip2 ? null
 , libedit ? null
 , libxcrypt-legacy ? null
 , ncurses5 ? null
@@ -19,6 +20,7 @@ let
 in
 
 assert stdenv.isLinux -> autoPatchelfHook != null;
+assert stdenv.isLinux -> bzip2 != null;
 assert stdenv.isLinux -> libxcrypt-legacy != null;
 assert stdenv.isLinux -> ncurses5 != null;
 assert stdenv.isLinux -> zlib != null;
@@ -60,6 +62,7 @@ let
     ];
 
     buildInputs = lib.optionals stdenv.isLinux ([
+      bzip2
       libxcrypt-legacy
       ncurses5
       stdenv.cc.cc.lib

--- a/pkgs/android/platform-tools.nix
+++ b/pkgs/android/platform-tools.nix
@@ -9,11 +9,6 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     buildInputs = [
       stdenv.cc.cc.lib
     ];
-
-    postUnpack = ''
-      autoPatchelf $out
-    '';
-
   } // {
   passthru.installSdk = ''
     for exe in adb dmtracedump e2fsdroid etc1tool fastboot hprof-conv make_f2fs mke2fs sload_f2fs; do

--- a/pkgs/android/prebuilt.nix
+++ b/pkgs/android/prebuilt.nix
@@ -3,6 +3,7 @@
 , autoPatchelfHook
 , mkGeneric
 , libedit
+, bzip2
 , ncurses5
 , zlib
 }:
@@ -16,7 +17,7 @@ let
     (
       if (hasPrefix "cmake;" id || hasPrefix "skiaparser;" id) then {
         nativeBuildInputs = [ autoPatchelfHook ];
-        buildInputs = [ ncurses5 stdenv.cc.cc.lib ];
+        buildInputs = [ bzip2 ncurses5 stdenv.cc.cc.lib ];
       }
       else { }
     );


### PR DESCRIPTION
Partially reverts #96 which broke many if not all binaries (see #103).

Many derivations rely on `mkGeneric` and use `autoPatchelfHook` as a native build input. Since `dontAutoPatchelf = true` was added to `mkGeneric` in #96, `autoPatchelfHook` never ran again, breaking all dynamic binaries.

This PR removes `dontAutoPatchelf = true` from `mkGeneric` and also adds some missing build inputs. This way, `autoPatchelf` will again run as a post-fixup and will also fail if it cannot resolve a dependency instead of silently succeeding.

Closes #103.
Supersedes #104.