### PR TITLE
updated default.nix - hostPlatform renamed to pkgs.stdenv.hostPlatform

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ let
 
   isSupported = _: pkg:
     (!lib.isDerivation pkg) ||
-    lib.meta.availableOn hostPlatform pkg ||
+    lib.meta.availableOn pkgs.stdenv.hostPlatform pkg ||
     config.allowUnsupportedSystem ||
     builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
 


### PR DESCRIPTION
As of nixos 25.11 an evaluation warning is thrown due to the renaming of "hostPlatform" to "stdenv.hostPlatform"