### PR TITLE
Remove references to python27 (removed from nixpkgs)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,18 @@
-{ pkgs ? import <nixpkgs> { }
-, channel ? "stable"
+{
+  pkgs ? import <nixpkgs> { },
+  channel ? "stable",
 }:
 
 with pkgs;
 let
   androidSdk = callPackage ./pkgs/android { };
 
-  isSupported = _: pkg:
-    (!lib.isDerivation pkg) ||
-    lib.meta.availableOn stdenv.hostPlatform pkg ||
-    config.allowUnsupportedSystem ||
-    builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+  isSupported =
+    _: pkg:
+    (!lib.isDerivation pkg)
+    || lib.meta.availableOn stdenv.hostPlatform pkg
+    || config.allowUnsupportedSystem
+    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
 
   filterIsSupported = lib.filterAttrs isSupported;
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,20 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, devshell, flake-utils }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      devshell,
+      flake-utils,
+    }:
     let
-      sdkPkgsFor = pkgs: import ./default.nix {
-        inherit pkgs;
-        channel = builtins.readFile ./channel;
-      };
+      sdkPkgsFor =
+        pkgs:
+        import ./default.nix {
+          inherit pkgs;
+          channel = builtins.readFile ./channel;
+        };
     in
     {
 
@@ -23,7 +31,8 @@
 
       hmModule = self.hmModules.android;
 
-      overlays.default = final: prev:
+      overlays.default =
+        final: prev:
         let
           android = sdkPkgsFor final;
         in
@@ -37,8 +46,8 @@
         description = "Android application or library";
       };
     }
-    //
-    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ] (system:
+    // flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ] (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -65,23 +74,28 @@
         };
 
         checks = {
-          lint = with pkgs; runCommandLocal "lint" { } ''
-            cd ${./.}
-            ${nixpkgs-fmt}/bin/nixpkgs-fmt --check *.nix pkgs/android/*.nix template/*.nix nix-android-repo/*.nix
-            echo "checked" > $out
-          '';
+          lint =
+            with pkgs;
+            runCommandLocal "lint" { } ''
+              cd ${./.}
+              ${nixfmt}/bin/nixfmt --check *.nix pkgs/android/*.nix template/*.nix nix-android-repo/*.nix
+              echo "checked" > $out
+            '';
 
-          sdk = self.sdk.${system} (sdkPkgs: with sdkPkgs; [
-            cmdline-tools-latest
-            build-tools-34-0-0
-            emulator
-            ndk-26-1-10909125
-            platform-tools
-            platforms-android-34
-            tools
-          ]);
+          sdk = self.sdk.${system} (
+            sdkPkgs: with sdkPkgs; [
+              cmdline-tools-latest
+              build-tools-34-0-0
+              emulator
+              ndk-26-1-10909125
+              platform-tools
+              platforms-android-34
+              tools
+            ]
+          );
         };
 
         packages = flake-utils.lib.flattenTree sdkPkgs.packages;
-      });
+      }
+    );
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let

--- a/nix-android-repo/default.nix
+++ b/nix-android-repo/default.nix
@@ -1,7 +1,8 @@
-{ devshellPkgs
-, gradle2nixBuilders
-, gradle2nixPkgs
-, pkgs
+{
+  devshellPkgs,
+  gradle2nixBuilders,
+  gradle2nixPkgs,
+  pkgs,
 }:
 
 let
@@ -11,7 +12,12 @@ let
 in
 rec {
   devshell = callPackage ./devshell.nix {
-    inherit devshellPkgs gradle2nix jdk update-locks;
+    inherit
+      devshellPkgs
+      gradle2nix
+      jdk
+      update-locks
+      ;
   };
 
   nix-android-repo = callPackage ./nix-android-repo.nix {

--- a/nix-android-repo/devshell.nix
+++ b/nix-android-repo/devshell.nix
@@ -1,8 +1,9 @@
-{ devshellPkgs
-, gradle
-, gradle2nix
-, jdk
-, update-locks
+{
+  devshellPkgs,
+  gradle,
+  gradle2nix,
+  jdk,
+  update-locks,
 }:
 
 devshellPkgs.mkShell {

--- a/nix-android-repo/flake.nix
+++ b/nix-android-repo/flake.nix
@@ -11,8 +11,16 @@
     };
   };
 
-  outputs = { self, nixpkgs, devshell, flake-utils, gradle2nix }:
-    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ] (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      devshell,
+      flake-utils,
+      gradle2nix,
+    }:
+    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ] (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         localPkgs = pkgs.callPackage ./default.nix {
@@ -37,7 +45,8 @@
         packages = {
           inherit (localPkgs)
             nix-android-repo
-            update-locks;
+            update-locks
+            ;
           inherit (gradle2nix.packages.${system}) gradle2nix;
           default = self.packages.${system}.nix-android-repo;
         };

--- a/nix-android-repo/nix-android-repo.nix
+++ b/nix-android-repo/nix-android-repo.nix
@@ -1,6 +1,7 @@
-{ buildGradlePackage
-, makeWrapper
-, jdk
+{
+  buildGradlePackage,
+  makeWrapper,
+  jdk,
 }:
 
 buildGradlePackage {

--- a/nix-android-repo/update-locks.nix
+++ b/nix-android-repo/update-locks.nix
@@ -1,9 +1,10 @@
-{ lib
-, writeShellScriptBin
-, git
-, gradle2nix
-, gradle
-, jdk
+{
+  lib,
+  writeShellScriptBin,
+  git,
+  gradle2nix,
+  gradle,
+  jdk,
 }:
 
 writeShellScriptBin "update-locks" ''

--- a/pkgs/android/build-tools.nix
+++ b/pkgs/android/build-tools.nix
@@ -1,38 +1,46 @@
-{ stdenv
-, lib
-, makeWrapper
-, mkGeneric
-, autoPatchelfHook
-, coreutils
-, jdk
-, libcxx
-, ncurses5
-, zlib
+{
+  stdenv,
+  lib,
+  makeWrapper,
+  mkGeneric,
+  autoPatchelfHook,
+  coreutils,
+  jdk,
+  libcxx,
+  ncurses5,
+  zlib,
 }:
 
-mkGeneric (lib.optionalAttrs stdenv.isLinux {
-  nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
-  ];
+mkGeneric (
+  lib.optionalAttrs stdenv.isLinux {
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeWrapper
+    ];
 
-  buildInputs = [
-    stdenv.cc.cc.lib
-    libcxx
-    ncurses5
-    zlib
-  ];
+    buildInputs = [
+      stdenv.cc.cc.lib
+      libcxx
+      ncurses5
+      zlib
+    ];
 
-  autoPatchelfIgnoreMissingDeps = true;
+    autoPatchelfIgnoreMissingDeps = true;
 
-  autoPatchelfCCWrappers = [
-    stdenv.cc
-  ];
+    autoPatchelfCCWrappers = [
+      stdenv.cc
+    ];
 
-  postUnpack = ''
-    for f in apksigner d8 lld; do
-      substituteInPlace "$out/$f" --replace "/bin/ls" "ls"
-      wrapProgram "$out/$f" --set PATH ${lib.makeBinPath [coreutils jdk]}
-    done
-  '';
-})
+    postUnpack = ''
+      for f in apksigner d8 lld; do
+        substituteInPlace "$out/$f" --replace "/bin/ls" "ls"
+        wrapProgram "$out/$f" --set PATH ${
+          lib.makeBinPath [
+            coreutils
+            jdk
+          ]
+        }
+      done
+    '';
+  }
+)

--- a/pkgs/android/cmdline-tools.nix
+++ b/pkgs/android/cmdline-tools.nix
@@ -1,7 +1,10 @@
-{ mkGeneric, openjdk, jdk ? openjdk }:
-
-mkGeneric
 {
+  mkGeneric,
+  openjdk,
+  jdk ? openjdk,
+}:
+
+mkGeneric {
   pname = "cmdline-tools";
 
   passthru.installSdk = ''

--- a/pkgs/android/default.nix
+++ b/pkgs/android/default.nix
@@ -1,15 +1,17 @@
 { pkgs, lib }:
 
-lib.makeScope pkgs.newScope (self: with self; {
-  fetchandroid = callPackage ./fetch.nix { };
-  mkGeneric = callPackage ./generic.nix { };
-  mkBuildTools = callPackage ./build-tools.nix { };
-  mkCmdlineTools = callPackage ./cmdline-tools.nix { };
-  mkEmulator = callPackage ./emulator.nix { };
-  mkNdk = callPackage ./ndk.nix { };
-  mkNdkBundle = callPackage ./ndk-bundle.nix { };
-  mkPlatformTools = callPackage ./platform-tools.nix { };
-  mkPrebuilt = callPackage ./prebuilt.nix { };
-  mkSrcOnly = callPackage ./src-only.nix { };
-  mkTools = callPackage ./tools.nix { };
-})
+lib.makeScope pkgs.newScope (
+  self: with self; {
+    fetchandroid = callPackage ./fetch.nix { };
+    mkGeneric = callPackage ./generic.nix { };
+    mkBuildTools = callPackage ./build-tools.nix { };
+    mkCmdlineTools = callPackage ./cmdline-tools.nix { };
+    mkEmulator = callPackage ./emulator.nix { };
+    mkNdk = callPackage ./ndk.nix { };
+    mkNdkBundle = callPackage ./ndk-bundle.nix { };
+    mkPlatformTools = callPackage ./platform-tools.nix { };
+    mkPrebuilt = callPackage ./prebuilt.nix { };
+    mkSrcOnly = callPackage ./src-only.nix { };
+    mkTools = callPackage ./tools.nix { };
+  }
+)

--- a/pkgs/android/emulator.nix
+++ b/pkgs/android/emulator.nix
@@ -1,48 +1,49 @@
-{ stdenv
-, lib
-, mkGeneric
-, makeWrapper
-, autoPatchelfHook
-, alsa-lib
-, dbus
-, fontconfig
-, freetype
-, gperftools
-, libGL
-, libICE
-, libSM
-, libX11
-, libXcomposite
-, libXcursor
-, libXdamage
-, libXext
-, libXfixes
-, libXi
-, libXrender
-, libXtst
-, libbsd
-, libcxx
-, libdrm
-, libgbm
-, libpulseaudio
-, libtiff
-, libudev0-shim
-, libunwind
-, libuuid
-, libxkbcommon
-, libxkbfile
-, ncurses5
-, nss
-, nspr
-, sqlite
-, systemd
-, waylandpp
-, xkeyboard_config
-, zlib
+{
+  stdenv,
+  lib,
+  mkGeneric,
+  makeWrapper,
+  autoPatchelfHook,
+  alsa-lib,
+  dbus,
+  fontconfig,
+  freetype,
+  gperftools,
+  libGL,
+  libICE,
+  libSM,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrender,
+  libXtst,
+  libbsd,
+  libcxx,
+  libdrm,
+  libgbm,
+  libpulseaudio,
+  libtiff,
+  libudev0-shim,
+  libunwind,
+  libuuid,
+  libxkbcommon,
+  libxkbfile,
+  ncurses5,
+  nss,
+  nspr,
+  sqlite,
+  systemd,
+  waylandpp,
+  xkeyboard_config,
+  zlib,
 }:
 
-mkGeneric (lib.optionalAttrs stdenv.isLinux
-  {
+mkGeneric (
+  lib.optionalAttrs stdenv.isLinux {
     nativeBuildInputs = [
       autoPatchelfHook
       makeWrapper
@@ -100,18 +101,22 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
       # Inject libudev0-shim to fix udev_loader error.
       wrapProgram $out/emulator \
         --set QT_QPA_PLATFORM xcb \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-          libudev0-shim
-          dbus
-          systemd
-        ]} \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            libudev0-shim
+            dbus
+            systemd
+          ]
+        } \
         --set QT_XKB_CONFIG_ROOT ${xkeyboard_config}/share/X11/xkb \
         --set QTCOMPOSE ${libX11.out}/share/X11/locale
     '';
-  } // {
-  passthru.installSdk = ''
-    for exe in emulator emulator-check mksdcard; do
-      ln -s $pkgBase/$exe $out/bin/$exe
-    done
-  '';
-})
+  }
+  // {
+    passthru.installSdk = ''
+      for exe in emulator emulator-check mksdcard; do
+        ln -s $pkgBase/$exe $out/bin/$exe
+      done
+    '';
+  }
+)

--- a/pkgs/android/fetch.nix
+++ b/pkgs/android/fetch.nix
@@ -1,6 +1,11 @@
-{ stdenv, lib, fetchurl, unzip }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  unzip,
+}:
 
-{ sources, ... } @ args:
+{ sources, ... }@args:
 let
   # Keys by which to search the package's "sources" set for the host platform.
   hostOsKeys = with stdenv.hostPlatform; [
@@ -10,14 +15,16 @@ let
     "all"
   ];
 
-  platformKey = lib.findFirst
-    (k: builtins.hasAttr k sources)
-    (throw "Unsupported system: ${stdenv.hostPlatform.system}")
-    hostOsKeys;
+  platformKey = lib.findFirst (
+    k: builtins.hasAttr k sources
+  ) (throw "Unsupported system: ${stdenv.hostPlatform.system}") hostOsKeys;
 
   src = sources.${platformKey};
 
 in
-(fetchurl ({
-  inherit (src) url sha1;
-} // removeAttrs args [ "sources" ]))
+(fetchurl (
+  {
+    inherit (src) url sha1;
+  }
+  // removeAttrs args [ "sources" ]
+))

--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -1,66 +1,92 @@
-{ stdenv, lib, fetchandroid, writeText, unzip }:
+{
+  stdenv,
+  lib,
+  fetchandroid,
+  writeText,
+  unzip,
+}:
 
 args: package:
 let
   inherit (builtins) attrNames hasAttr;
   inherit (lib) flatten;
 
-  platforms = flatten (map
-    (name: if (hasAttr name lib.platforms) then lib.platforms.${name} else name)
-    (attrNames package.sources));
+  platforms = flatten (
+    map (name: if (hasAttr name lib.platforms) then lib.platforms.${name} else name) (
+      attrNames package.sources
+    )
+  );
 
 in
-stdenv.mkDerivation ({
-  # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
-  dontStrip = true;
-  dontPatchELF = true;
+stdenv.mkDerivation (
+  {
+    # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
+    dontStrip = true;
+    dontPatchELF = true;
 
-  inherit (package) pname version;
+    inherit (package) pname version;
 
-  nativeBuildInputs = [ unzip ] ++ (args.nativeBuildInputs or [ ]);
+    nativeBuildInputs = [ unzip ] ++ (args.nativeBuildInputs or [ ]);
 
-  src = fetchandroid {
-    inherit (package) sources;
-  };
+    src = fetchandroid {
+      inherit (package) sources;
+    };
 
-  setSourceRoot = ''
-    sourceRoot="$out"
-  '';
+    setSourceRoot = ''
+      sourceRoot="$out"
+    '';
 
-  unpackCmd = ''
-    if ! [[ "$curSrc" =~ \.zip$ ]]; then return 1; fi
+    unpackCmd = ''
+      if ! [[ "$curSrc" =~ \.zip$ ]]; then return 1; fi
 
-    unzip-strip() (
-        local zip=$1
-        local dest=''${2:-.}
-        local temp=$(mktemp -d) && unzip -qq -d "$temp" "$zip" && mkdir -p "$dest" &&
-        shopt -s dotglob && local f=("$temp"/*) &&
-        if (( ''${#f[@]} == 1 )) && [[ -d "''${f[0]}" ]] ; then
-            mv "$temp"/*/* "$dest"
-        else
-            mv "$temp"/* "$dest"
-        fi && rmdir "$temp"/* "$temp"
-    )
+      unzip-strip() (
+          local zip=$1
+          local dest=''${2:-.}
+          local temp=$(mktemp -d) && unzip -qq -d "$temp" "$zip" && mkdir -p "$dest" &&
+          shopt -s dotglob && local f=("$temp"/*) &&
+          if (( ''${#f[@]} == 1 )) && [[ -d "''${f[0]}" ]] ; then
+              mv "$temp"/*/* "$dest"
+          else
+              mv "$temp"/* "$dest"
+          fi && rmdir "$temp"/* "$temp"
+      )
 
-    unzip-strip "$curSrc" "$out"
-  '';
+      unzip-strip "$curSrc" "$out"
+    '';
 
-  installPhase = args.installPhase or ''
-    runHook preInstall
-    runHook postInstall
-  '';
+    installPhase =
+      args.installPhase or ''
+        runHook preInstall
+        runHook postInstall
+      '';
 
-  passthru = {
-    inherit (package) id license path xml;
-  } // (args.passthru or { });
+    passthru = {
+      inherit (package)
+        id
+        license
+        path
+        xml
+        ;
+    }
+    // (args.passthru or { });
 
-  preferLocalBuild = true;
+    preferLocalBuild = true;
 
-  meta = with lib; {
-    description = package.displayName;
-    homepage = "https://developer.android.com/studio/";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ tadfisher ];
-    inherit platforms;
-  } // (args.meta or { });
-} // removeAttrs args [ "nativeBuildInputs" "passthru" "meta" "unzipCmd" ])
+    meta =
+      with lib;
+      {
+        description = package.displayName;
+        homepage = "https://developer.android.com/studio/";
+        license = licenses.asl20;
+        maintainers = with maintainers; [ tadfisher ];
+        inherit platforms;
+      }
+      // (args.meta or { });
+  }
+  // removeAttrs args [
+    "nativeBuildInputs"
+    "passthru"
+    "meta"
+    "unzipCmd"
+  ]
+)

--- a/pkgs/android/ndk.nix
+++ b/pkgs/android/ndk.nix
@@ -1,23 +1,16 @@
-{ lib
-, stdenv
-, mkGeneric
-, makeWrapper
-, pkgsHostHost
-, autoPatchelfHook ? null
-, bzip2 ? null
-, libedit ? null
-, libxcrypt-legacy ? null
-, ncurses5 ? null
-, openssl ? null
-, sqlite ? null
-, python27 ? null
-, zlib ? null
+{
+  lib,
+  stdenv,
+  mkGeneric,
+  makeWrapper,
+  pkgsHostHost,
+  autoPatchelfHook ? null,
+  bzip2 ? null,
+  libedit ? null,
+  libxcrypt-legacy ? null,
+  ncurses5 ? null,
+  zlib ? null,
 }:
-
-let
-  python27Versions = [ "16" "21" ];
-
-in
 
 assert stdenv.isLinux -> autoPatchelfHook != null;
 assert stdenv.isLinux -> bzip2 != null;
@@ -34,17 +27,20 @@ in
 assert (stdenv.isLinux && lib.versionOlder versionMajor "18") -> libedit != null;
 
 let
-  runtimePaths = lib.makeBinPath (with pkgsHostHost; [
-    coreutils
-    file
-    findutils
-    gawk
-    gnugrep
-    gnused
-    jdk
-    python3
-    which
-  ]);
+  runtimePaths = lib.makeBinPath (
+    with pkgsHostHost;
+    [
+      coreutils
+      file
+      findutils
+      gawk
+      gnugrep
+      gnused
+      jdk
+      python3
+      which
+    ]
+  );
 
   searchPaths = [
     "prebuilt/linux-x86_64/lib"
@@ -57,44 +53,42 @@ let
   buildArgs = {
     nativeBuildInputs = [
       makeWrapper
-    ] ++ lib.optionals stdenv.isLinux [
+    ]
+    ++ lib.optionals stdenv.isLinux [
       autoPatchelfHook
     ];
 
-    buildInputs = lib.optionals stdenv.isLinux ([
-      bzip2
-      libxcrypt-legacy
-      ncurses5
-      stdenv.cc.cc.lib
-      zlib
-    ] ++ lib.optionals (lib.versionOlder versionMajor "18") [
-      libedit
-    ] ++ lib.optionals (builtins.elem versionMajor python27Versions) [
-      python27
-    ]);
+    buildInputs = lib.optionals stdenv.isLinux (
+      [
+        bzip2
+        libxcrypt-legacy
+        ncurses5
+        stdenv.cc.cc.lib
+        zlib
+      ]
+      ++ lib.optionals (lib.versionOlder versionMajor "18") [
+        libedit
+      ]
+    );
 
     postFixup = ''
       patchShebangs .
 
       ${lib.optionalString (stdenv.isLinux && lib.versionOlder versionMajor "18") ''
-      ln -sf ${libedit}/lib/libedit.so $out/toolchains/llvm/prebuilt/linux-x86_64/lib64/libedit.so.2
-      ''}
-
-      ${lib.optionalString (stdenv.isLinux && builtins.elem versionMajor python27Versions) ''
-      rm -rf $out/prebuilt/*/lib/python2.7
+        ln -sf ${libedit}/lib/libedit.so $out/toolchains/llvm/prebuilt/linux-x86_64/lib64/libedit.so.2
       ''}
 
       ${lib.optionalString (stdenv.isLinux) ''
-      for path in ${toString searchPaths}; do
-        addAutoPatchelfSearchPath "$out/$path"
-      done
-      find $out/toolchains -type d -name bin -or -name lib64 | while read dir; do
-        autoPatchelf "$dir"
-      done
-      # Patch executables
-      if [ -d $out/prebuilt/linux-x86_64 ]; then
-         autoPatchelf $out/prebuilt/linux-x86_64
-      fi
+        for path in ${toString searchPaths}; do
+          addAutoPatchelfSearchPath "$out/$path"
+        done
+        find $out/toolchains -type d -name bin -or -name lib64 | while read dir; do
+          autoPatchelf "$dir"
+        done
+        # Patch executables
+        if [ -d $out/prebuilt/linux-x86_64 ]; then
+           autoPatchelf $out/prebuilt/linux-x86_64
+        fi
       ''}
 
       # fix ineffective PROGDIR / MYNDKDIR determination
@@ -104,7 +98,8 @@ let
     '';
 
     autoPatchelfIgnoreMissingDeps = [ "liblog.so" ];
-  } // {
+  }
+  // {
     passthru.installSdk = ''
       ln -sf $pkgBase/ndk-build $out/bin/ndk-build
     '';

--- a/pkgs/android/platform-tools.nix
+++ b/pkgs/android/platform-tools.nix
@@ -1,7 +1,12 @@
-{ stdenv, lib, mkGeneric, autoPatchelfHook }:
+{
+  stdenv,
+  lib,
+  mkGeneric,
+  autoPatchelfHook,
+}:
 
-mkGeneric (lib.optionalAttrs stdenv.isLinux
-  {
+mkGeneric (
+  lib.optionalAttrs stdenv.isLinux {
     nativeBuildInputs = [
       autoPatchelfHook
     ];
@@ -9,11 +14,13 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
     buildInputs = [
       stdenv.cc.cc.lib
     ];
-  } // {
-  passthru.installSdk = ''
-    for exe in adb dmtracedump e2fsdroid etc1tool fastboot hprof-conv make_f2fs mke2fs sload_f2fs; do
-      ln -s $pkgBase/$exe $out/bin/$exe
-    done
-    ln -s $pkgBase/systrace/systrace.py $out/bin/systrace
-  '';
-})
+  }
+  // {
+    passthru.installSdk = ''
+      for exe in adb dmtracedump e2fsdroid etc1tool fastboot hprof-conv make_f2fs mke2fs sload_f2fs; do
+        ln -s $pkgBase/$exe $out/bin/$exe
+      done
+      ln -s $pkgBase/systrace/systrace.py $out/bin/systrace
+    '';
+  }
+)

--- a/pkgs/android/prebuilt.nix
+++ b/pkgs/android/prebuilt.nix
@@ -1,11 +1,12 @@
-{ stdenv
-, lib
-, autoPatchelfHook
-, mkGeneric
-, libedit
-, bzip2
-, ncurses5
-, zlib
+{
+  stdenv,
+  lib,
+  autoPatchelfHook,
+  mkGeneric,
+  libedit,
+  bzip2,
+  ncurses5,
+  zlib,
 }:
 
 { id, ... }@package:
@@ -13,14 +14,19 @@ let
   inherit (builtins) replaceStrings;
   inherit (lib) hasPrefix recursiveUpdate;
 
-  buildArgs = lib.optionalAttrs stdenv.isLinux
-    (
-      if (hasPrefix "cmake;" id || hasPrefix "skiaparser;" id) then {
+  buildArgs = lib.optionalAttrs stdenv.isLinux (
+    if (hasPrefix "cmake;" id || hasPrefix "skiaparser;" id) then
+      {
         nativeBuildInputs = [ autoPatchelfHook ];
-        buildInputs = [ bzip2 ncurses5 stdenv.cc.cc.lib ];
+        buildInputs = [
+          bzip2
+          ncurses5
+          stdenv.cc.cc.lib
+        ];
       }
-      else { }
-    );
+    else
+      { }
+  );
 
 in
 mkGeneric buildArgs package

--- a/pkgs/android/sdk.nix
+++ b/pkgs/android/sdk.nix
@@ -1,11 +1,30 @@
-{ stdenv, lib, runCommand, linkFarm, makeWrapper, writeShellScript, writeText, packages }:
+{
+  stdenv,
+  lib,
+  runCommand,
+  linkFarm,
+  makeWrapper,
+  writeShellScript,
+  writeText,
+  packages,
+}:
 
 pkgsFun:
 let
   inherit (builtins) attrValues concatStringsSep length;
 
-  inherit (lib) all any assertMsg concatMapStringsSep filterAttrs groupBy groupBy'
-    mapAttrs mapAttrsToList unique;
+  inherit (lib)
+    all
+    any
+    assertMsg
+    concatMapStringsSep
+    filterAttrs
+    groupBy
+    groupBy'
+    mapAttrs
+    mapAttrsToList
+    unique
+    ;
 
   packages' = filterAttrs (_: p: lib.isDerivation p) packages;
 
@@ -14,79 +33,96 @@ let
   duplicates = filterAttrs (path: ps: (length ps) > 1) (groupBy (p: p.path) pkgs);
 
   duplicateMsg =
-    let msg = path: ps: "${path}:\n" + concatMapStringsSep "\n" (p: "  ${p.name}") ps;
-    in concatStringsSep "\n\n" (mapAttrsToList msg duplicates);
+    let
+      msg = path: ps: "${path}:\n" + concatMapStringsSep "\n" (p: "  ${p.name}") ps;
+    in
+    concatStringsSep "\n\n" (mapAttrsToList msg duplicates);
 
   licenses =
     let
-      licenseHashes = groupBy' (sum: p: unique (sum ++ [ p.license.hash ])) [ ] (p: p.license.id) (builtins.attrValues packages');
-      licenseFiles = mapAttrs (id: hashes: writeText id ("\n" + (concatStringsSep "\n" hashes))) licenseHashes;
+      licenseHashes = groupBy' (sum: p: unique (sum ++ [ p.license.hash ])) [ ] (p: p.license.id) (
+        builtins.attrValues packages'
+      );
+      licenseFiles = mapAttrs (
+        id: hashes: writeText id ("\n" + (concatStringsSep "\n" hashes))
+      ) licenseHashes;
     in
-    linkFarm "android-licenses" (mapAttrsToList (id: file: { name = id; path = file; }) licenseFiles);
+    linkFarm "android-licenses" (
+      mapAttrsToList (id: file: {
+        name = id;
+        path = file;
+      }) licenseFiles
+    );
 
-  installSdk = concatMapStringsSep "\n"
-    (pkg: ''
-      pkgBase="$ANDROID_SDK_ROOT/${pkg.path}"
-      mkdir -p "$(dirname $pkgBase)"
-      cp -as ${pkg}/ $pkgBase
-      chmod +w $pkgBase
-      cp "${pkg.xml}" $pkgBase/package.xml
-      ${pkg.installSdk or ""}
-    '')
-    pkgs;
+  installSdk = concatMapStringsSep "\n" (pkg: ''
+    pkgBase="$ANDROID_SDK_ROOT/${pkg.path}"
+    mkdir -p "$(dirname $pkgBase)"
+    cp -as ${pkg}/ $pkgBase
+    chmod +w $pkgBase
+    cp "${pkg.xml}" $pkgBase/package.xml
+    ${pkg.installSdk or ""}
+  '') pkgs;
 
-  sdk = runCommand "android-sdk-env"
-    {
-      name = "android-sdk-env";
-      buildInputs = [ licenses ] ++ pkgs;
-      nativeBuildInputs = [ makeWrapper ];
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-      setupHook = writeText "setup-hook" ''
-        export ANDROID_SDK_ROOT="@out@/share/android-sdk"
-        # Android Studio uses this even though it is deprecated.
-        export ANDROID_HOME="$ANDROID_SDK_ROOT"
+  sdk =
+    runCommand "android-sdk-env"
+      {
+        name = "android-sdk-env";
+        buildInputs = [ licenses ] ++ pkgs;
+        nativeBuildInputs = [ makeWrapper ];
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        setupHook = writeText "setup-hook" ''
+          export ANDROID_SDK_ROOT="@out@/share/android-sdk"
+          # Android Studio uses this even though it is deprecated.
+          export ANDROID_HOME="$ANDROID_SDK_ROOT"
+        '';
+        shellHook = ''
+          echo Using Android SDK root: $out/share/android-sdk
+          export ANDROID_SDK_ROOT="$out/share/android-sdk"
+          # Android Studio uses this even though it is deprecated.
+          export ANDROID_HOME="$ANDROID_SDK_ROOT"
+        '';
+        passthru.packages = pkgs;
+      }
+      ''
+        export ANDROID_SDK_ROOT=$out/share/android-sdk
+        mkdir -p "$ANDROID_SDK_ROOT"
+        mkdir -p "$out/bin"
+
+        ${installSdk}
+
+        mkdir -p "$ANDROID_SDK_ROOT/licenses"
+        cp -as ${licenses}/* "$ANDROID_SDK_ROOT/licenses"
+
+        export ANDROID_SDK_HOME=$(mktemp -d)
+        touch $ANDROID_SDK_HOME/repositories.cfg
+        $out/bin/sdkmanager --list --verbose
+
+        # Normally done in fixupPhase
+        source ${stdenv.setup}
+        mkdir -p "$out/nix-support"
+        substituteAll "$setupHook" "$out/nix-support/setup-hook"
       '';
-      shellHook = ''
-        echo Using Android SDK root: $out/share/android-sdk
-        export ANDROID_SDK_ROOT="$out/share/android-sdk"
-        # Android Studio uses this even though it is deprecated.
-        export ANDROID_HOME="$ANDROID_SDK_ROOT"
-      '';
-      passthru.packages = pkgs;
-    } ''
-    export ANDROID_SDK_ROOT=$out/share/android-sdk
-    mkdir -p "$ANDROID_SDK_ROOT"
-    mkdir -p "$out/bin"
-
-    ${installSdk}
-
-    mkdir -p "$ANDROID_SDK_ROOT/licenses"
-    cp -as ${licenses}/* "$ANDROID_SDK_ROOT/licenses"
-
-    export ANDROID_SDK_HOME=$(mktemp -d)
-    touch $ANDROID_SDK_HOME/repositories.cfg
-    $out/bin/sdkmanager --list --verbose
-
-    # Normally done in fixupPhase
-    source ${stdenv.setup}
-    mkdir -p "$out/nix-support"
-    substituteAll "$setupHook" "$out/nix-support/setup-hook"
-  '';
 
 in
-assert (assertMsg (duplicates == { })
-  ''
+assert (
+  assertMsg (duplicates == { }) ''
     The following SDK packages collide:
 
     ${duplicateMsg}
   ''
 );
 
-assert (assertMsg (all (p: p.name != "tools") pkgs)
-  "The 'tools' package is obsolete. Use 'cmdline-tools' instead.");
+assert (
+  assertMsg (all (
+    p: p.name != "tools"
+  ) pkgs) "The 'tools' package is obsolete. Use 'cmdline-tools' instead."
+);
 
-assert (assertMsg (any (p: p.pname == "cmdline-tools") pkgs)
-  "Missing 'cmdline-tools' package, which is required for a working Android SDK.");
+assert (
+  assertMsg (any (
+    p: p.pname == "cmdline-tools"
+  ) pkgs) "Missing 'cmdline-tools' package, which is required for a working Android SDK."
+);
 
 sdk

--- a/pkgs/android/tools.nix
+++ b/pkgs/android/tools.nix
@@ -1,24 +1,25 @@
-{ stdenv
-, lib
-, mkGeneric
-, autoPatchelfHook
-, makeWrapper
-, findutils
-, coreutils
-, fontconfig
-, freetype
-, jdk8
-, libX11
-, libXdamage
-, libXrender
-, libXext
-, libpulseaudio
-, ncurses5
-, zlib
+{
+  stdenv,
+  lib,
+  mkGeneric,
+  autoPatchelfHook,
+  makeWrapper,
+  findutils,
+  coreutils,
+  fontconfig,
+  freetype,
+  jdk8,
+  libX11,
+  libXdamage,
+  libXrender,
+  libXext,
+  libpulseaudio,
+  ncurses5,
+  zlib,
 }:
 
-mkGeneric (lib.optionalAttrs stdenv.isLinux
-  {
+mkGeneric (
+  lib.optionalAttrs stdenv.isLinux {
     nativeBuildInputs = [
       autoPatchelfHook
       findutils
@@ -42,15 +43,17 @@ mkGeneric (lib.optionalAttrs stdenv.isLinux
         substituteInPlace $f --replace "/bin/ls" "${coreutils}/bin/ls"
       done
     '';
-  } // {
-  passthru.installSdk = ''
-    shopt -s extglob
-    for exe in $pkgBase/bin/!(sdkmanager); do
-      makeWrapper $exe $out/bin/$(basename $exe) --set JAVA_HOME "${jdk8.home}"
-    done
-    makeWrapper $pkgBase/bin/sdkmanager $out/bin/sdkmanager \
-      --add-flags '--sdk_root="$ANDROID_HOME"' \
-      --set JAVA_HOME "${jdk8.home}" \
-      --set-default ANDROID_HOME $ANDROID_HOME 
-  '';
-})
+  }
+  // {
+    passthru.installSdk = ''
+      shopt -s extglob
+      for exe in $pkgBase/bin/!(sdkmanager); do
+        makeWrapper $exe $out/bin/$(basename $exe) --set JAVA_HOME "${jdk8.home}"
+      done
+      makeWrapper $pkgBase/bin/sdkmanager $out/bin/sdkmanager \
+        --add-flags '--sdk_root="$ANDROID_HOME"' \
+        --set JAVA_HOME "${jdk8.home}" \
+        --set-default ANDROID_HOME $ANDROID_HOME 
+    '';
+  }
+)

--- a/template/devshell.nix
+++ b/template/devshell.nix
@@ -34,5 +34,6 @@ devshell.mkShell {
     android-sdk
     gradle
     jdk
-  ] ++ conditionalPackages;
+  ]
+  ++ conditionalPackages;
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -8,14 +8,21 @@
     android.url = "github:tadfisher/android-nixpkgs";
   };
 
-  outputs = { self, nixpkgs, devshell, flake-utils, android }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      devshell,
+      flake-utils,
+      android,
+    }:
     {
       overlay = final: prev: {
         inherit (self.packages.${final.system}) android-sdk android-studio;
       };
     }
-    //
-    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ] (system:
+    // flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ] (
+      system:
       let
         inherit (nixpkgs) lib;
         pkgs = import nixpkgs {
@@ -29,28 +36,33 @@
       in
       {
         packages = {
-          android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
-            # Useful packages for building and testing.
-            build-tools-34-0-0
-            cmdline-tools-latest
-            emulator
-            platform-tools
-            platforms-android-34
+          android-sdk = android.sdk.${system} (
+            sdkPkgs:
+            with sdkPkgs;
+            [
+              # Useful packages for building and testing.
+              build-tools-34-0-0
+              cmdline-tools-latest
+              emulator
+              platform-tools
+              platforms-android-34
 
-            # Other useful packages for a development environment.
-            # ndk-26-1-10909125
-            # skiaparser-3
-            # sources-android-34
-          ]
-          ++ lib.optionals (system == "aarch64-darwin") [
-            # system-images-android-34-google-apis-arm64-v8a
-            # system-images-android-34-google-apis-playstore-arm64-v8a
-          ]
-          ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
-            # system-images-android-34-google-apis-x86-64
-            # system-images-android-34-google-apis-playstore-x86-64
-          ]);
-        } // lib.optionalAttrs (system == "x86_64-linux") {
+              # Other useful packages for a development environment.
+              # ndk-26-1-10909125
+              # skiaparser-3
+              # sources-android-34
+            ]
+            ++ lib.optionals (system == "aarch64-darwin") [
+              # system-images-android-34-google-apis-arm64-v8a
+              # system-images-android-34-google-apis-playstore-arm64-v8a
+            ]
+            ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
+              # system-images-android-34-google-apis-x86-64
+              # system-images-android-34-google-apis-playstore-x86-64
+            ]
+          );
+        }
+        // lib.optionalAttrs (system == "x86_64-linux") {
           # Android Studio in nixpkgs is currently packaged for x86_64-linux only.
           android-studio = pkgs.androidStudioPackages.stable;
           # android-studio = pkgs.androidStudioPackages.beta;


### PR DESCRIPTION
`python27` was removed from nixpkgs. This may break these specific versions of the NDK (16.x and 21.x), but they are ancient.